### PR TITLE
fix(meetings): getSession is not a function

### DIFF
--- a/src/pages/user/[id]/meetings/new.tsx
+++ b/src/pages/user/[id]/meetings/new.tsx
@@ -21,6 +21,7 @@ import {
 	createLogger,
 	LoggerTypes
 } from 'lib/logger'
+import { getSession } from 'lib/api/utils/getSession'
 import {
 	useState
 } from 'react'
@@ -69,8 +70,6 @@ export const getServerSideProps: GetServerSideProps =
 		} catch (e) {
 			userId = -1
 		}
-		// import { getSession } from 'lib/api/utils/getSession'
-		const getSession = require('../../../../lib/api/utils/getSession')
 		const session = await getSession(context)
 		if (!session || userId === -1) {
 			return {


### PR DESCRIPTION
```
2021-01-25T08:59:54.597045+00:00 app[web.1]: TypeError: getSession is not a function
2021-01-25T08:59:54.597058+00:00 app[web.1]:     at getServerSideProps (/app/.next/server/pages/user/[id]/meetings/new.js:3055:25)
2021-01-25T08:59:54.597059+00:00 app[web.1]:     at renderToHTML (/app/node_modules/next/next-server/server/render.tsx:767:22)
2021-01-25T08:59:54.597059+00:00 app[web.1]:     at processTicksAndRejections (node:internal/process/task_queues:94:5)
2021-01-25T08:59:54.597060+00:00 app[web.1]:     at /app/node_modules/next/next-server/server/next-server.ts:1554:26
2021-01-25T08:59:54.597062+00:00 app[web.1]:     at /app/node_modules/next/next-server/server/next-server.ts:1484:25
2021-01-25T08:59:54.597063+00:00 app[web.1]:     at Server.renderToHTMLWithComponents (/app/node_modules/next/next-server/server/next-server.ts:1654:9)
2021-01-25T08:59:54.597063+00:00 app[web.1]:     at Server.renderToHTML (/app/node_modules/next/next-server/server/next-server.ts:1750:22)
2021-01-25T08:59:54.597063+00:00 app[web.1]:     at Server.render (/app/node_modules/next/next-server/server/next-server.ts:1216:18)
2021-01-25T08:59:54.597064+00:00 app[web.1]:     at Object.fn (/app/node_modules/next/next-server/server/next-server.ts:937:9)
2021-01-25T08:59:54.597064+00:00 app[web.1]:     at Router.execute (/app/node_modules/next/next-server/server/router.ts:247:24)
```