### PR TITLE
fix(ts): typescript build error

### DIFF
--- a/src/components/User/ToggleFriendButton.tsx
+++ b/src/components/User/ToggleFriendButton.tsx
@@ -1,4 +1,4 @@
-import { Button, PropTypes } from '@material-ui/core'
+import type { PropTypes } from '@material-ui/core'
 import { FriendshipTypeResponse } from '../../lib/api/users/[id]/FriendshipType'
 import assertUnreachable from '../../lib/utils/assertUnreachable'
 import type { UserPublicSearchResult } from '../../lib/api/users/UserPublic'


### PR DESCRIPTION
Fix Heroku build deploy error:
```
Type error: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.

> 1 | import { Button, PropTypes } from '@material-ui/core'

    | ^

  2 | import { FriendshipTypeResponse } from '../../lib/api/users/[id]/FriendshipType'

  3 | import assertUnreachable from '../../lib/utils/assertUnreachable'

  4 | import type { UserPublicSearchResult } from '../../lib/api/users/UserPublic'
```