### PR TITLE
fix(sound): music overlap (fixes #27)

### DIFF
--- a/src/components/pages/welcome/AddFriends.tsx
+++ b/src/components/pages/welcome/AddFriends.tsx
@@ -169,7 +169,6 @@ export function AddFriends(
 						)
 				}
 			</Box>
-			<BackgroundMusic source={SoundPaths.BgMusic}/>
 		</NextOrSkipWrapper>
 	)
 }

--- a/src/components/pages/welcome/AddMeeting.tsx
+++ b/src/components/pages/welcome/AddMeeting.tsx
@@ -42,7 +42,6 @@ export function AddMeeting(
 		const friendsResults: UserPublicSearchResult[] =
 			await fetchUsers()
 
-		// console.log({searchResults})
 		if (friendsResults && friendsResults.length > 0) {
 			const mappedResults: Record<number, UserPublicSearchResult> = {}
 			friendsResults.forEach(usr => {
@@ -57,6 +56,9 @@ export function AddMeeting(
 
 	useEffect(() => {
 		setLoading(false)
+		//FIXME: https://juliangaramendy.dev/blog/use-promise-subscription
+		//       memory leak, stop the getFriends from setting state after it was
+		//                    unmounted
 		getFriends().catch((err) => {
 			console.error('get friends failed', err)
 		})

--- a/src/components/sounds/ButtonWithSound.tsx
+++ b/src/components/sounds/ButtonWithSound.tsx
@@ -27,8 +27,10 @@ export default function ButtonWithSound(
 		onClick={(e) => {
 			console.log('button-with-sound playing', data)
 			if(!data.isPlaying) {
-				play({})
+				play()
 			}
+			// FIXME: the below function may be a setstate and it somehow
+			//         causes memory leaks? (according to console logs)
 			props.onClick && props.onClick(e)
 		}}
 	>

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -4,13 +4,15 @@ import { WelcomeInner } from './welcome'
 import { useCallback, useState } from 'react'
 import { useHello } from '../../lib/utils/useSpeech'
 import { useSession } from '../../lib/api/utils/useSession'
+import BackgroundMusic from '../../components/sounds/BackgroundMusic'
+import { SoundPaths } from '../../components/sounds/soundPaths'
 
 export default function App(): JSX.Element {
 	const [finished, setFinished] = useState(false)
 	const [session, loading] = useSession()
 	useHello(
 		useCallback(() => {
-			if(!session) {
+			if (!session) {
 				return undefined
 			}
 			let firstName = session.user.name.split(' ')[0]
@@ -25,15 +27,17 @@ export default function App(): JSX.Element {
 	return (
 		<Protected>
 			<Layout>
-				{
-					!finished ?
-						<WelcomeInner
-							onFinish={() => setFinished(true)}
-						/> :
-						<>
-							this is a work in progress wait till we add more stuff pls
-						</>
-				}
+				<BackgroundMusic source={SoundPaths.BgMusic}>
+					{
+						!finished ?
+							<WelcomeInner
+								onFinish={() => setFinished(true)}
+							/> :
+							<>
+								this is a work in progress wait till we add more stuff pls
+							</>
+					}
+				</BackgroundMusic>
 			</Layout>
 		</Protected>
 	)


### PR DESCRIPTION
because BackgroundMusic was a regular component
any rerenders caused the play function to be called
(despite having a hasPlayed ref which should have
persisted across re-renders which I dont understand,
but whats understandable eis that the useSound hook
got a different `data` parameter and that caused the
`data.isPlaying` to be a false negative). Another way
to have fixed this might have been wrapping this
component in some sort of memoization React structure
that would only re-render this component if the given
props have changed (but on second thought this might
not have worked, because the `BackgroundMusic`
component was only rerendered because the parent
`AddFriends` was rerendererd as well...

I've decided to change the `BackgroundMusic`
component to be a context, but I don't think it being
now a context is what fixed it but rather that it is
higher in the DOM hierarchy so it only reloads on
the page changing (?) not sure exactly

the `MusicProvider` is using a context internally
so i think this should now enable some UI to be able
to change settings like whether sound can play etc.